### PR TITLE
feat: performing specific preprocess operation to specific endpoint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
     "editor.formatOnSave": true,
     "javascript.preferences.quoteStyle": "auto",
-    "prettier.singleQuote": true
+    "editor.tabSize": 2,
 }

--- a/functions/ldap.js
+++ b/functions/ldap.js
@@ -14,26 +14,26 @@ exports.plugin = {
   name: 'ldap',
   register: async function (server) {
       server.ext('onPostAuth', (request, h) => {
-          if (request.path === '/ldap/search') {
-              let { tlsOptions, attributes } = request.query;
+        if (request.path === '/ldap/search') {
+          let { tlsOptions, attributes } = request.query;
 
-              if (tlsOptions) {
-                  tlsOptions = Qs.parse(tlsOptions, {
-                      delimiter: /[;,]/,
-                  });
+          if (tlsOptions) {
+            tlsOptions = Qs.parse(tlsOptions, {
+              delimiter: /[;,]/,
+            });
 
-                  request.query.tlsOptions = tlsOptions;
-              }
-
-              if (attributes && !Array.isArray(attributes)) {
-                  attributes = [attributes];
-
-                  request.query.attributes = attributes;
-              }
+            request.query.tlsOptions = tlsOptions;
           }
 
-      return h.continue;
-    });
+          if (attributes && !Array.isArray(attributes)) {
+            attributes = [attributes];
+
+            request.query.attributes = attributes;
+          }
+        }
+
+        return h.continue;
+      });
     server.route({
       method: 'GET',
       path: '/ldap/search',

--- a/functions/ldap.js
+++ b/functions/ldap.js
@@ -13,22 +13,24 @@ const Qs = require('qs');
 exports.plugin = {
   name: 'ldap',
   register: async function (server) {
-    server.ext('onRequest', (request, h) => {
-      let { tlsOptions, attributes } = request.query;
+      server.ext('onPostAuth', (request, h) => {
+          if (request.path === '/ldap/search') {
+              let { tlsOptions, attributes } = request.query;
 
-      if (tlsOptions) {
-        tlsOptions = Qs.parse(tlsOptions, {
-          delimiter: /[;,]/,
-        });
+              if (tlsOptions) {
+                  tlsOptions = Qs.parse(tlsOptions, {
+                      delimiter: /[;,]/,
+                  });
 
-        request.query.tlsOptions = tlsOptions;
-      }
+                  request.query.tlsOptions = tlsOptions;
+              }
 
-      if (attributes && !Array.isArray(attributes)) {
-        attributes = [attributes];
+              if (attributes && !Array.isArray(attributes)) {
+                  attributes = [attributes];
 
-        request.query.attributes = attributes;
-      }
+                  request.query.attributes = attributes;
+              }
+          }
 
       return h.continue;
     });

--- a/functions/ldap.js
+++ b/functions/ldap.js
@@ -13,27 +13,27 @@ const Qs = require('qs');
 exports.plugin = {
   name: 'ldap',
   register: async function (server) {
-      server.ext('onPostAuth', (request, h) => {
-        if (request.path === '/ldap/search') {
-          let { tlsOptions, attributes } = request.query;
+    server.ext('onPostAuth', (request, h) => {
+      if (request.path === '/ldap/search') {
+        let { tlsOptions, attributes } = request.query;
 
-          if (tlsOptions) {
-            tlsOptions = Qs.parse(tlsOptions, {
-              delimiter: /[;,]/,
-            });
+        if (tlsOptions) {
+          tlsOptions = Qs.parse(tlsOptions, {
+            delimiter: /[;,]/,
+          });
 
-            request.query.tlsOptions = tlsOptions;
-          }
-
-          if (attributes && !Array.isArray(attributes)) {
-            attributes = [attributes];
-
-            request.query.attributes = attributes;
-          }
+          request.query.tlsOptions = tlsOptions;
         }
 
-        return h.continue;
-      });
+        if (attributes && !Array.isArray(attributes)) {
+          attributes = [attributes];
+
+          request.query.attributes = attributes;
+        }
+      }
+
+      return h.continue;
+    });
     server.route({
       method: 'GET',
       path: '/ldap/search',


### PR DESCRIPTION
## Problem/Issue:
GET /ldap/search pre-process operation is is taking effect to all endpoints because the extension function is a listener to all routes.

Trello issue [here](https://trello.com/c/2uLo774L/184-get-ldap-search-to-adjust-pre-process-operation)

## Proposed Solution:
To add condition by filtering the process to only take effect to the specific endpoint.